### PR TITLE
Fix "Prop editor: Right-click draws auto-tiles, instead of removing"

### DIFF
--- a/src/Rained/EditorGui/Editors/TileEditor/TileEditor.cs
+++ b/src/Rained/EditorGui/Editors/TileEditor/TileEditor.cs
@@ -507,7 +507,7 @@ partial class TileEditor : IEditorMode
                     // remove tile on right click
                     if (!removedOnSameCell && isMouseHeldInMode && EditorWindow.IsMouseDown(ImGuiMouseButton.Right) && mouseCell.HasTile())
                     {
-                        if (selectionMode == SelectionMode.Tiles || (selectionMode == SelectionMode.Materials && !disallowMatOverwrite))
+                        if (selectionMode == SelectionMode.Autotiles || selectionMode == SelectionMode.Tiles || (selectionMode == SelectionMode.Materials && !disallowMatOverwrite))
                         {
                             removedOnSameCell = true;
                             level.RemoveTileCell(window.WorkLayer, window.MouseCx, window.MouseCy, modifyGeometry);
@@ -1001,7 +1001,7 @@ partial class TileEditor : IEditorMode
         bool endOnClick = RainEd.Instance.Preferences.AutotileMouseMode == UserPreferences.AutotileMouseModeOptions.Click;
 
         // if mouse was pressed
-        if (isToolActive && !wasToolActive)
+        if (isToolActive && !wasToolActive && !KeyShortcuts.Active(KeyShortcut.RightMouse))
         {
             if (activePathBuilder is null)
             {


### PR DESCRIPTION
Fix: Prop editor: Right-click draws auto-tiles, instead of removing them #18 