### PR TITLE
Fix file browser modal opening off-screen on smaller/4:3 displays

### DIFF
--- a/src/Rained/EditorGui/FileBrowser.cs
+++ b/src/Rained/EditorGui/FileBrowser.cs
@@ -431,6 +431,21 @@ partial class FileBrowser
             ImGui.SetNextWindowSize(windowSize, ImGuiCond.FirstUseEver);
         }
 
+        // Constrain the window to the work area EVERY frame. The popup persists its
+        // size in imgui.ini (shared across machines), and SetNextWindowSize above only
+        // clamps on FirstUseEver — so a size saved on a larger monitor is restored
+        // verbatim on a smaller/4:3 screen, opening the modal taller than the display
+        // with its title bar and OK/Cancel buttons off-screen. Being modal, that blocks
+        // the whole app while appearing not to display. Clamping max to WorkSize here
+        // prevents the window from ever exceeding the current screen.
+        {
+            var workSize = ImGui.GetMainViewport().WorkSize;
+            var minSize = Vector2.Min(
+                new Vector2(ImGui.GetTextLineHeight() * 30f, ImGui.GetTextLineHeight() * 20f),
+                workSize);
+            ImGui.SetNextWindowSizeConstraints(minSize, workSize);
+        }
+
         if (ImGui.BeginPopupModal(winName + "###File Browser"))
         {
             var windowSize = ImGui.GetWindowSize();


### PR DESCRIPTION
## Problem

On a smaller (e.g. 4:3 laptop) display, the Open/Save file browser fails to display and blocks the whole app: being modal, it eats all input, but its title bar and the OK/Cancel buttons are off the bottom of the screen, so there's no way to interact with or dismiss it.

## Cause

The file browser popup persists its size in `imgui.ini`, but `SetNextWindowSize` clamps to the display only with `ImGuiCond.FirstUseEver`:

```csharp
windowSize.Y = Math.Min(ImGui.GetMainViewport().WorkSize.Y - 50f, windowSize.Y);
ImGui.SetNextWindowSize(windowSize, ImGuiCond.FirstUseEver);
```

When the same config is reused across machines (or after moving from a larger monitor to a smaller one), the size saved on the large display is restored verbatim — `FirstUseEver` never re-clamps it — so the modal opens taller than the current screen with its controls off-screen.

## Fix

Add `SetNextWindowSizeConstraints(min, viewport.WorkSize)` before `BeginPopupModal` every frame, so the window can never exceed the current display regardless of what's stored in `imgui.ini`. Position is already re-centered on appear, so that side was already fine. No behavior change on displays large enough to hold the default size.

One file changed (`src/Rained/EditorGui/FileBrowser.cs`).